### PR TITLE
Add bson-support to protoc

### DIFF
--- a/protoc-gen-go/generator/bson_extensions.go
+++ b/protoc-gen-go/generator/bson_extensions.go
@@ -1,0 +1,91 @@
+package generator
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	bsonTagPattern        = "@bson_tag: (.*)"
+	bsonCompatiblePattern = "@bson_compatible"
+	bsonUpsertablePattern = "@bson_upsertable"
+	goInjectPattern       = `(?s)@go_inject\s(.+)`
+	// TODO: This import pattern doesn't support aliased imports
+	goImportPattern = `@import[ \t]+"([^"]+)"`
+)
+
+var bsonTagRegex, bsonCompatibleRegex, bsonUpsertableRegex, goInjectRegex, goImportRegex *regexp.Regexp
+
+func init() {
+	bsonTagRegex = regexp.MustCompile(bsonTagPattern)
+	bsonCompatibleRegex = regexp.MustCompile(bsonCompatiblePattern)
+	bsonUpsertableRegex = regexp.MustCompile(bsonUpsertablePattern)
+	goInjectRegex = regexp.MustCompile(goInjectPattern)
+	goImportRegex = regexp.MustCompile(goImportPattern)
+}
+
+func (g *Generator) IsMessageBsonCompatible(message *Descriptor) bool {
+	if loc, ok := g.file.comments[message.path]; ok {
+		preMessageComments := strings.TrimSuffix(loc.GetLeadingComments(), "\n")
+		return bsonCompatibleRegex.Match([]byte(preMessageComments))
+	}
+
+	return false
+}
+
+func (g *Generator) IsMessageBsonUpsertable(message *Descriptor) bool {
+	if loc, ok := g.file.comments[message.path]; ok {
+		preMessageComments := strings.TrimSuffix(loc.GetLeadingComments(), "\n")
+		return bsonUpsertableRegex.Match([]byte(preMessageComments))
+	}
+
+	return false
+}
+
+func (g *Generator) GetBsonTagForField(message *Descriptor, fieldNumber int) string {
+	fieldPath := fmt.Sprintf("%s,%d,%d", message.path, messageFieldPath, fieldNumber)
+	if loc, ok := g.file.comments[fieldPath]; ok {
+		allFieldComments := []string{loc.GetTrailingComments(), loc.GetLeadingComments()}
+
+		for _, fieldComment := range allFieldComments {
+			fieldComment = strings.TrimSuffix(fieldComment, "\n")
+			matchedGroups := bsonTagRegex.FindStringSubmatch(fieldComment)
+			if matchedGroups != nil {
+				return strings.TrimSpace(matchedGroups[1])
+			}
+		}
+	}
+
+	return ""
+}
+
+func (g *Generator) GetGoInjectForMessage(message *Descriptor) string {
+	if loc, ok := g.file.comments[message.path]; ok {
+		allLeadingComments := loc.GetLeadingDetachedComments()
+		allLeadingComments = append(allLeadingComments, loc.GetLeadingComments())
+
+		for _, leadingComment := range allLeadingComments {
+			matchedGroups := goInjectRegex.FindStringSubmatch(leadingComment)
+			if matchedGroups != nil {
+				return matchedGroups[1]
+			}
+		}
+	}
+
+	return ""
+}
+
+func goImportsFromGoInject(injectBlock string) []string {
+	matches := goImportRegex.FindAllStringSubmatch(injectBlock, -1)
+	imports := []string{}
+	for _, match := range matches {
+		imports = append(imports, match[1])
+	}
+
+	return imports
+}
+
+func goCodeFromGoInject(injectBlock string) string {
+	return goImportRegex.ReplaceAllString(injectBlock, "")
+}


### PR DESCRIPTION
Usage Overview

@bson_compatible: An annotation on a message that inserts a bson annotation with a lowerCamelCased name for every field by default.

Example:
// @bson_compatible
message Foo {
  bar string
}

@bson_upsertable: An annotation on a message that works like bson_compatible, but each annotation is 'omitempty' by default.

@bson_tag: An annotation on a field that overrides any default bson annotation behavior.

Example:
// @bson_compatible
message Foo {
  bar string // @bson_tag: othername,omitempty
  baz string // this does default
}

@go_inject: An annotation block _ahead_ of a message that will inject the block directly into the generated go-code.
@import: An annotation contained _inside_ a @go_inject block that allows defining required imports

Example:

/* go_inject

@import "encoding/hex"

func Anything(p *Point) string {
  return p.Bar + hex.EncodeToString([]byte{32})
}

*/
message Point {
  bar string
}



Example